### PR TITLE
Update libdatachannel and cpp-httplib to v0.23.1

### DIFF
--- a/.github/workflows/peerconnection-test.yml
+++ b/.github/workflows/peerconnection-test.yml
@@ -24,7 +24,13 @@ jobs:
       - uses: actions/checkout@v2
       - name: Update submodules
         if: matrix.library == 'libdatachannel'
-        run: git submodule update --init --recursive
+        run: |
+          # fetch cpp-httplib locked in .git/index
+          git submodule update --init libdatachannel/deps/cpp-httplib
+          # fetch the newest libdatachannel
+          git submodule update --init --remote libdatachannel/deps/libdatachannel
+          # fetch cpp-httplib and libdatachannel deps (if there are any) locked in their .git/index
+          git submodule foreach --recursive git submodule update --init
       - name: Build ${{ matrix.library }} and push to GitHub container registry.
         run: |
           echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u sipsorcery --password-stdin

--- a/.github/workflows/peerconnection-test.yml
+++ b/.github/workflows/peerconnection-test.yml
@@ -24,13 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Update submodules
         if: matrix.library == 'libdatachannel'
-        run: |
-          # fetch cpp-httplib locked in .git/index
-          git submodule update --init libdatachannel/deps/cpp-httplib
-          # fetch the newest libdatachannel
-          git submodule update --init --remote libdatachannel/deps/libdatachannel
-          # fetch cpp-httplib and libdatachannel deps (if there are any) locked in their .git/index
-          git submodule foreach --recursive git submodule update --init
+        run: git submodule update --init --recursive
       - name: Build ${{ matrix.library }} and push to GitHub container registry.
         run: |
           echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u sipsorcery --password-stdin

--- a/libdatachannel/Dockerfile
+++ b/libdatachannel/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye AS build
+FROM debian:bookworm AS build
 RUN apt-get update
 RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y gcc g++ make cmake libssl-dev
 COPY libdatachannel /src/
@@ -6,9 +6,9 @@ WORKDIR /src
 RUN cmake -B build
 WORKDIR /src/build
 RUN make -j4
-FROM debian:bullseye AS final
+FROM debian:bookworm AS final
 RUN apt-get update
-RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y libstdc++6 libssl1.1
+RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y libstdc++6 libssl3
 WORKDIR /app
 COPY --from=build /src/build/client .
 COPY --from=build /src/build/server .

--- a/libdatachannel/README.md
+++ b/libdatachannel/README.md
@@ -6,16 +6,7 @@ C++17 WebRTC echo client and server with libdatachannel.
 
 You need cmake and the development libraries with header files for either OpenSSL or GnuTLS. On Debian/Ubuntu, you can install them with either `$ apt install libssl-dev` or `$ apt install libgnutls28-dev`.
 
-Additionally, be sure the submodules are updated with:
-
-```sh
-# fetch cpp-httplib locked in .git/index
-git submodule update --init libdatachannel/deps/cpp-httplib
-# fetch the newest libdatachannel
-git submodule update --init --remote libdatachannel/deps/libdatachannel
-# fetch cpp-httplib and libdatachannel deps (if there are any) locked in their .git/index
-git submodule foreach --recursive git submodule update --init
-```
+Additionally, be sure the submodules are updated with `git submodule update --init --recursive`.
 
 For building on Windows vcpkg can be used to install the required dependencies:
 

--- a/libdatachannel/README.md
+++ b/libdatachannel/README.md
@@ -6,7 +6,16 @@ C++17 WebRTC echo client and server with libdatachannel.
 
 You need cmake and the development libraries with header files for either OpenSSL or GnuTLS. On Debian/Ubuntu, you can install them with either `$ apt install libssl-dev` or `$ apt install libgnutls28-dev`.
 
-Additionally, be sure the submodules are updated with `git submodule update --init --recursive`.
+Additionally, be sure the submodules are updated with:
+
+```sh
+# fetch cpp-httplib locked in .git/index
+git submodule update --init libdatachannel/deps/cpp-httplib
+# fetch the newest libdatachannel
+git submodule update --init --remote libdatachannel/deps/libdatachannel
+# fetch cpp-httplib and libdatachannel deps (if there are any) locked in their .git/index
+git submodule foreach --recursive git submodule update --init
+```
 
 For building on Windows vcpkg can be used to install the required dependencies:
 

--- a/libdatachannel/client.cpp
+++ b/libdatachannel/client.cpp
@@ -115,7 +115,7 @@ int main(int argc, char **argv) try {
 				auto res = cl.Post(path.c_str(), dumped.c_str(), "application/json");
 				if (!res)
 					throw std::runtime_error("HTTP request to " + url +
-					                         " failed; error code: " + std::to_string(res.error()));
+					                         " failed; error code: " + http::to_string(res.error()));
 
 				if (res->status != 200)
 					throw std::runtime_error("HTTP POST failed with status " +

--- a/libdatachannel/server.cpp
+++ b/libdatachannel/server.cpp
@@ -82,7 +82,7 @@ int main(int argc, char **argv) try {
 		res.set_content(body, "application/json");
 	});
 
-	srv.set_exception_handler([](const http::Request &req, http::Response &res, std::exception &e) {
+	srv.set_exception_handler([](const http::Request &req, http::Response &res, std::exception_ptr e) {
 		res.status = 500;
 		res.set_content("500 Internal Server Error", "text/plain");
 	});


### PR DESCRIPTION
This PR:
* ~~fixes fetching the newest libdatachannel version on the CI. TL;DR submodules versions are locked in `.git/index`. Executing `git submodule update --init --recursive` does not sync submodules with their remotes. To do so, one has to use `--remote` option. It's also important that we don't want to use `--remote` for `cpp-httplib` (as there might be breaking changes) and for `libdatachannel`'s submodules (for the same reason).~~ **After discussion on libdatachannel discord, this change has been removed in 57668e8f30697445c6009d71675745dd17304856. Instead, just update libdatachannel time to time**
* updates cpp-httplib, and libdatachannel and its Dockerfile. libdatachannel update should also fix aiortc <-> libdatachannel interoperability. The problem was in incorrect DTLS certificate version, which was fixed in https://github.com/paullouisageneau/libdatachannel/pull/1406 and https://github.com/paullouisageneau/libdatachannel/pull/1411 