### PR TITLE
werift: fix client crash by running compiled client.js

### DIFF
--- a/werift/client-datachannel.sh
+++ b/werift/client-datachannel.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-DEBUG=werift* node -r ts-node/register client.ts $1 -t 1
+# Run the compiled client for the Data Channel Echo test.
+DEBUG=werift* node client.js $1 -t 1

--- a/werift/client.sh
+++ b/werift/client.sh
@@ -1,2 +1,6 @@
 #!/bin/bash
-DEBUG=werift* node -r ts-node/register client.ts $1
+# Run the compiled client (built by `npm run build` in the Dockerfile).
+# Avoid ts-node at runtime: modern werift type defs break outdated ts-node/TS combos.
+# Note: $1 is intentionally unquoted so Data Channel CI args like
+# "-s http://echo-server:8080/offer -t 1" are word-split for yargs.
+DEBUG=werift* node client.js $1


### PR DESCRIPTION
## Summary

Fixes the post-#74 interop client crash when using `werift` as the client peer.

### Failure

Job example: https://github.com/sipsorcery/webrtc-interop/actions/runs/31050850584/job/92458099614#step:3:104

```
Error: Debug Failure. False expression: Non-string value passed to
`ts.resolveTypeReferenceDirective`, likely by a wrapping package working
with an outdated `resolveTypeReferenceDirectives` signature.
```

### Cause

`/client.sh` ran TypeScript via outdated `ts-node` at container runtime:

```bash
node -r ts-node/register client.ts $1
```

With `werift@latest`, that combination blows up during type resolution before any signaling happens. The Dockerfile already builds to JS (`npm run build`) and the server entrypoint already uses `node server.js`.

### Fix

- `werift/client.sh` → `node client.js $1`
- `werift/client-datachannel.sh` → `node client.js $1 -t 1`

### Verification

Local Docker rebuild + `/client.sh http://127.0.0.1:9/offer` now starts werift, produces an SDP offer, and fails only with the expected connection error (no ts-node crash).

## Test plan

- [ ] CI rebuilds `werift` image successfully
- [ ] Peer Connection jobs with `client=werift` no longer fail at step 3 with the TypeScript Debug Failure
- [ ] Data Channel jobs with `client=werift` still accept `-s ... -t 1` via unquoted `$1` word-splitting